### PR TITLE
refactor: rename project terminology to plan terminology throughout codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Valkey MCP Task Management Server
 
-A task management system that implements the Model Context Protocol (MCP) for seamless integration with agentic AI tools. This system allows AI agents to create, manage, and track tasks within projects using Valkey as the persistence layer.
+A task management system that implements the Model Context Protocol (MCP) for seamless integration with agentic AI tools. This system allows AI agents to create, manage, and track tasks within plans using Valkey as the persistence layer.
 
 ## Features
 
-- Project management (create, read, update, delete)
+- Plan management (create, read, update, delete)
 - Task management (create, read, update, delete)
 - Task ordering and prioritization
 - Status tracking for tasks

--- a/go/README.md
+++ b/go/README.md
@@ -51,8 +51,8 @@ go/
 
 The MCP server exposes the following endpoints:
 
-- `list_resources` - List available resources (projects and tasks)
-- `read_resource` - Read a specific resource (project or task)
+- `list_resources` - List available resources (plans and tasks)
+- `read_resource` - Read a specific resource (plan or task)
 - `create_resource` - Create a new resource
 - `update_resource` - Update an existing resource
 - `delete_resource` - Delete a resource

--- a/go/cmd/mcpserver/main.go
+++ b/go/cmd/mcpserver/main.go
@@ -44,11 +44,14 @@ func main() {
 	log.Printf("Connected to Valkey at %s:%d", valkeyHost, valkeyPort)
 
 	// Initialize repositories
-	projectRepo := storage.NewProjectRepository(valkeyClient)
+	planRepo := storage.NewPlanRepository(valkeyClient)
 	taskRepo := storage.NewTaskRepository(valkeyClient)
 
 	// Create MCP server using the mark3labs/mcp-go library
-	mcpServer := mcp.NewMCPGoServer(*projectRepo, *taskRepo)
+	// Convert concrete types to interfaces
+	var planRepoInterface storage.PlanRepositoryInterface = planRepo
+	var taskRepoInterface storage.TaskRepositoryInterface = taskRepo
+	mcpServer := mcp.NewMCPGoServer(planRepoInterface, taskRepoInterface)
 
 	// Set up signal handling for graceful shutdown
 	quit := make(chan os.Signal, 1)

--- a/go/go.mod
+++ b/go/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.37.0
 	github.com/testcontainers/testcontainers-go/modules/valkey v0.37.0
-	github.com/valkey-io/valkey-glide/go/v2 v2.0.0-rc6
+	github.com/valkey-io/valkey-glide/go/v2 v2.0.0
 )
 
 require (

--- a/go/go.sum
+++ b/go/go.sum
@@ -110,8 +110,8 @@ github.com/tklauser/go-sysconf v0.3.14 h1:g5vzr9iPFFz24v2KZXs/pvpvh8/V9Fw6vQK5ZZ
 github.com/tklauser/go-sysconf v0.3.14/go.mod h1:1ym4lWMLUOhuBOPGtRcJm7tEGX4SCYNEEEtghGG/8uY=
 github.com/tklauser/numcpus v0.8.0 h1:Mx4Wwe/FjZLeQsK/6kt2EOepwwSl7SmJrK5bV/dXYgY=
 github.com/tklauser/numcpus v0.8.0/go.mod h1:ZJZlAY+dmR4eut8epnzf0u/VwodKmryxR8txiloSqBE=
-github.com/valkey-io/valkey-glide/go/v2 v2.0.0-rc6 h1:kUUNaXrrEiMD5oLq97Dt+XHwOADpl5qjaQ5yznA4Q8k=
-github.com/valkey-io/valkey-glide/go/v2 v2.0.0-rc6/go.mod h1:LK5zmODJa5xnxZndarh1trntExb3GVGJXz4GwDCagho=
+github.com/valkey-io/valkey-glide/go/v2 v2.0.0 h1:8t07VSF7WI1O3C4yHHRb+EtUiPO+5Wj2/viYeKtAm5g=
+github.com/valkey-io/valkey-glide/go/v2 v2.0.0/go.mod h1:LK5zmODJa5xnxZndarh1trntExb3GVGJXz4GwDCagho=
 github.com/valkey-io/valkey-go v1.0.41 h1:pWgh9MP24Vl0ANZ0KxEMwB/LHvTUKwlm2SPuWIrSlFw=
 github.com/valkey-io/valkey-go v1.0.41/go.mod h1:LXqAbjygRuA1YRocojTslAGx2dQB4p8feaseGviWka4=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=

--- a/go/internal/mocks/mock_plan_repository.go
+++ b/go/internal/mocks/mock_plan_repository.go
@@ -1,0 +1,106 @@
+package mocks
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jbrinkman/valkey-ai-tasks/go/internal/models"
+	"github.com/jbrinkman/valkey-ai-tasks/go/internal/storage"
+)
+
+// MockPlanRepository is an in-memory implementation of PlanRepositoryInterface for testing
+type MockPlanRepository struct {
+	mu    sync.RWMutex
+	plans map[string]*models.Plan
+}
+
+// NewMockPlanRepository creates a new mock plan repository
+func NewMockPlanRepository() *MockPlanRepository {
+	return &MockPlanRepository{
+		plans: make(map[string]*models.Plan),
+	}
+}
+
+// Create adds a new plan to the mock storage
+func (r *MockPlanRepository) Create(ctx context.Context, applicationID, name, description string) (*models.Plan, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	id := uuid.New().String()
+	plan := models.NewPlan(id, applicationID, name, description)
+	r.plans[id] = plan
+	return plan, nil
+}
+
+// Get retrieves a plan from the mock storage
+func (r *MockPlanRepository) Get(ctx context.Context, id string) (*models.Plan, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	plan, exists := r.plans[id]
+	if !exists {
+		return nil, fmt.Errorf("plan not found: %s", id)
+	}
+	return plan, nil
+}
+
+// Update modifies an existing plan in the mock storage
+func (r *MockPlanRepository) Update(ctx context.Context, plan *models.Plan) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	_, exists := r.plans[plan.ID]
+	if !exists {
+		return fmt.Errorf("plan not found: %s", plan.ID)
+	}
+
+	// Update the modification time
+	plan.UpdatedAt = time.Now()
+	r.plans[plan.ID] = plan
+	return nil
+}
+
+// Delete removes a plan from the mock storage
+func (r *MockPlanRepository) Delete(ctx context.Context, id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	_, exists := r.plans[id]
+	if !exists {
+		return fmt.Errorf("plan not found: %s", id)
+	}
+	delete(r.plans, id)
+	return nil
+}
+
+// List returns all plans from the mock storage
+func (r *MockPlanRepository) List(ctx context.Context) ([]*models.Plan, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	plans := make([]*models.Plan, 0, len(r.plans))
+	for _, plan := range r.plans {
+		plans = append(plans, plan)
+	}
+	return plans, nil
+}
+
+// ListByApplication returns plans for a specific application from the mock storage
+func (r *MockPlanRepository) ListByApplication(ctx context.Context, applicationID string) ([]*models.Plan, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	plans := make([]*models.Plan, 0)
+	for _, plan := range r.plans {
+		if plan.ApplicationID == applicationID {
+			plans = append(plans, plan)
+		}
+	}
+	return plans, nil
+}
+
+// Ensure MockPlanRepository implements the PlanRepositoryInterface
+var _ storage.PlanRepositoryInterface = (*MockPlanRepository)(nil)

--- a/go/internal/models/plan.go
+++ b/go/internal/models/plan.go
@@ -1,0 +1,62 @@
+package models
+
+import (
+	"time"
+)
+
+// Plan represents a collection of related tasks
+type Plan struct {
+	ID            string    `json:"id"`
+	ApplicationID string    `json:"application_id"` // Added field for application association
+	Name          string    `json:"name"`
+	Description   string    `json:"description"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+// NewPlan creates a new plan with the given name and description
+func NewPlan(id, applicationID, name, description string) *Plan {
+	now := time.Now()
+	return &Plan{
+		ID:            id,
+		ApplicationID: applicationID,
+		Name:          name,
+		Description:   description,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+}
+
+// ToMap converts the plan to a map for storage in Valkey
+func (p *Plan) ToMap() map[string]string {
+	return map[string]string{
+		"id":             p.ID,
+		"application_id": p.ApplicationID,
+		"name":           p.Name,
+		"description":    p.Description,
+		"created_at":     p.CreatedAt.Format(time.RFC3339),
+		"updated_at":     p.UpdatedAt.Format(time.RFC3339),
+	}
+}
+
+// FromMap populates a plan from a map retrieved from Valkey
+func (p *Plan) FromMap(data map[string]string) error {
+	p.ID = data["id"]
+	p.ApplicationID = data["application_id"]
+	p.Name = data["name"]
+	p.Description = data["description"]
+
+	createdAt, err := time.Parse(time.RFC3339, data["created_at"])
+	if err != nil {
+		return err
+	}
+	p.CreatedAt = createdAt
+
+	updatedAt, err := time.Parse(time.RFC3339, data["updated_at"])
+	if err != nil {
+		return err
+	}
+	p.UpdatedAt = updatedAt
+
+	return nil
+}

--- a/go/internal/models/task.go
+++ b/go/internal/models/task.go
@@ -24,10 +24,10 @@ const (
 	TaskPriorityHigh   TaskPriority = "high"
 )
 
-// Task represents an individual task within a project
+// Task represents an individual task within a plan
 type Task struct {
 	ID          string       `json:"id"`
-	ProjectID   string       `json:"project_id"`
+	PlanID      string       `json:"plan_id"`
 	Title       string       `json:"title"`
 	Description string       `json:"description"`
 	Status      TaskStatus   `json:"status"`
@@ -38,16 +38,16 @@ type Task struct {
 }
 
 // NewTask creates a new task with the given details
-func NewTask(id, projectID, title, description string, priority TaskPriority) *Task {
+func NewTask(id, planID, title, description string, priority TaskPriority) *Task {
 	now := time.Now()
 	return &Task{
 		ID:          id,
-		ProjectID:   projectID,
+		PlanID:      planID,
 		Title:       title,
 		Description: description,
 		Status:      TaskStatusPending,
 		Priority:    priority,
-		Order:       0, // Will be set when added to the project
+		Order:       0, // Will be set when added to the plan
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}
@@ -57,7 +57,7 @@ func NewTask(id, projectID, title, description string, priority TaskPriority) *T
 func (t *Task) ToMap() map[string]string {
 	return map[string]string{
 		"id":          t.ID,
-		"project_id":  t.ProjectID,
+		"plan_id":     t.PlanID,
 		"title":       t.Title,
 		"description": t.Description,
 		"status":      string(t.Status),
@@ -71,7 +71,7 @@ func (t *Task) ToMap() map[string]string {
 // FromMap populates a task from a map retrieved from Valkey
 func (t *Task) FromMap(data map[string]string) error {
 	t.ID = data["id"]
-	t.ProjectID = data["project_id"]
+	t.PlanID = data["plan_id"]
 	t.Title = data["title"]
 	t.Description = data["description"]
 	t.Status = TaskStatus(data["status"])

--- a/go/internal/storage/interfaces.go
+++ b/go/internal/storage/interfaces.go
@@ -6,7 +6,17 @@ import (
 	"github.com/jbrinkman/valkey-ai-tasks/go/internal/models"
 )
 
-// ProjectRepositoryInterface defines the interface for project storage operations
+// PlanRepositoryInterface defines the interface for plan storage operations
+type PlanRepositoryInterface interface {
+	Create(ctx context.Context, applicationID, name, description string) (*models.Plan, error)
+	Get(ctx context.Context, id string) (*models.Plan, error)
+	Update(ctx context.Context, plan *models.Plan) error
+	Delete(ctx context.Context, id string) error
+	List(ctx context.Context) ([]*models.Plan, error)
+	ListByApplication(ctx context.Context, applicationID string) ([]*models.Plan, error)
+}
+
+// ProjectRepositoryInterface defines the legacy interface for project storage operations
 type ProjectRepositoryInterface interface {
 	Create(ctx context.Context, applicationID, name, description string) (*models.Project, error)
 	Get(ctx context.Context, id string) (*models.Project, error)
@@ -18,15 +28,16 @@ type ProjectRepositoryInterface interface {
 
 // TaskRepositoryInterface defines the interface for task storage operations
 type TaskRepositoryInterface interface {
-	Create(ctx context.Context, projectID, title, description string, priority models.TaskPriority) (*models.Task, error)
-	CreateBulk(ctx context.Context, projectID string, tasks []TaskCreateInput) ([]*models.Task, error)
+	Create(ctx context.Context, planID, title, description string, priority models.TaskPriority) (*models.Task, error)
+	CreateBulk(ctx context.Context, planID string, tasks []TaskCreateInput) ([]*models.Task, error)
 	Get(ctx context.Context, id string) (*models.Task, error)
 	Update(ctx context.Context, task *models.Task) error
 	Delete(ctx context.Context, id string) error
-	ListByProject(ctx context.Context, projectID string) ([]*models.Task, error)
+	ListByPlan(ctx context.Context, planID string) ([]*models.Task, error)
 	ListByStatus(ctx context.Context, status models.TaskStatus) ([]*models.Task, error)
+	ReorderTask(ctx context.Context, taskID string, newOrder int) error
 }
 
 // Ensure the concrete types implement the interfaces
-var _ ProjectRepositoryInterface = (*ProjectRepository)(nil)
+var _ PlanRepositoryInterface = (*PlanRepository)(nil)
 var _ TaskRepositoryInterface = (*TaskRepository)(nil)

--- a/go/internal/storage/plan_repository.go
+++ b/go/internal/storage/plan_repository.go
@@ -1,0 +1,207 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	uuid "github.com/google/uuid"
+	"github.com/jbrinkman/valkey-ai-tasks/go/internal/models"
+)
+
+// PlanRepository handles storage operations for plans
+type PlanRepository struct {
+	client *ValkeyClient
+}
+
+// NewPlanRepository creates a new plan repository
+func NewPlanRepository(client *ValkeyClient) *PlanRepository {
+	return &PlanRepository{
+		client: client,
+	}
+}
+
+// Create adds a new plan to the storage
+func (r *PlanRepository) Create(ctx context.Context, applicationID, name, description string) (*models.Plan, error) {
+	// Generate a unique ID for the plan
+	id := uuid.New().String()
+
+	// Create a new plan
+	plan := models.NewPlan(id, applicationID, name, description)
+
+	// Store the plan in Valkey
+	planKey := GetPlanKey(id)
+	_, err := r.client.client.HSet(ctx, planKey, plan.ToMap())
+	if err != nil {
+		return nil, fmt.Errorf("failed to store plan: %w", err)
+	}
+
+	// Add plan ID to the plans list
+	_, err = r.client.client.SAdd(ctx, plansListKey, []string{id})
+	if err != nil {
+		// Try to clean up the plan if adding to the set fails
+		r.client.client.Del(ctx, []string{planKey})
+		return nil, fmt.Errorf("failed to add plan to list: %w", err)
+	}
+
+	// Add plan ID to the application-specific plans list
+	appPlansKey := fmt.Sprintf("app:%s:plans", applicationID)
+	_, err = r.client.client.SAdd(ctx, appPlansKey, []string{id})
+	if err != nil {
+		return nil, fmt.Errorf("failed to add plan to application list: %w", err)
+	}
+
+	return plan, nil
+}
+
+// Get retrieves a plan by ID
+func (r *PlanRepository) Get(ctx context.Context, id string) (*models.Plan, error) {
+	planKey := GetPlanKey(id)
+	result, err := r.client.client.HGetAll(ctx, planKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve plan: %w", err)
+	}
+
+	if len(result) == 0 {
+		return nil, fmt.Errorf("plan not found: %s", id)
+	}
+
+	plan := &models.Plan{}
+	err = plan.FromMap(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse plan data: %w", err)
+	}
+
+	return plan, nil
+}
+
+// Update updates an existing plan
+func (r *PlanRepository) Update(ctx context.Context, plan *models.Plan) error {
+	// Update the updated_at timestamp
+	plan.UpdatedAt = time.Now()
+
+	// Store the updated plan in Valkey
+	planKey := GetPlanKey(plan.ID)
+	_, err := r.client.client.HSet(ctx, planKey, plan.ToMap())
+	if err != nil {
+		return fmt.Errorf("failed to update plan: %w", err)
+	}
+
+	return nil
+}
+
+// Delete removes a plan and all its tasks
+func (r *PlanRepository) Delete(ctx context.Context, id string) error {
+	// Get the plan first to verify it exists
+	plan, err := r.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	// Get all tasks for this plan
+	planTasksKey := GetPlanTasksKey(id)
+	taskIDs, err := r.client.client.SMembers(ctx, planTasksKey)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve plan tasks: %w", err)
+	}
+
+	// Delete all tasks
+	for taskID := range taskIDs {
+		taskKey := GetTaskKey(taskID)
+		_, err := r.client.client.Del(ctx, []string{taskKey})
+		if err != nil {
+			return fmt.Errorf("failed to delete task %s: %w", taskID, err)
+		}
+	}
+
+	// Delete the plan tasks set
+	_, err = r.client.client.Del(ctx, []string{planTasksKey})
+	if err != nil {
+		return fmt.Errorf("failed to delete plan tasks set: %w", err)
+	}
+
+	// Delete the plan
+	planKey := GetPlanKey(id)
+	_, err = r.client.client.Del(ctx, []string{planKey})
+	if err != nil {
+		return fmt.Errorf("failed to delete plan: %w", err)
+	}
+
+	// Remove the plan from the plans list
+	_, err = r.client.client.SRem(ctx, plansListKey, []string{id})
+	if err != nil {
+		return fmt.Errorf("failed to remove plan from list: %w", err)
+	}
+
+	// Remove the plan from the application-specific plans list
+	appPlansKey := fmt.Sprintf("app:%s:plans", plan.ApplicationID)
+	_, err = r.client.client.SRem(ctx, appPlansKey, []string{id})
+	if err != nil {
+		return fmt.Errorf("failed to remove plan from application list: %w", err)
+	}
+
+	return nil
+}
+
+// List returns all plans
+func (r *PlanRepository) List(ctx context.Context) ([]*models.Plan, error) {
+	// Get all plan IDs
+	planIDs, err := r.client.client.SMembers(ctx, plansListKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve plan IDs: %w", err)
+	}
+
+	// Get each plan
+	plans := make([]*models.Plan, 0, len(planIDs))
+	for id := range planIDs {
+		plan, err := r.Get(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		plans = append(plans, plan)
+	}
+
+	return plans, nil
+}
+
+// ListByApplication retrieves all plans for a specific application
+func (r *PlanRepository) ListByApplication(ctx context.Context, applicationID string) ([]*models.Plan, error) {
+	// Get all plan IDs for this application
+	appPlansKey := fmt.Sprintf("app:%s:plans", applicationID)
+	planIDs, err := r.client.client.SMembers(ctx, appPlansKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve application plan IDs: %w", err)
+	}
+
+	// If there are no plans, return an empty slice
+	if len(planIDs) == 0 {
+		return []*models.Plan{}, nil
+	}
+
+	// Get each plan
+	plans := make([]*models.Plan, 0, len(planIDs))
+	for id := range planIDs {
+		// Get the plan data
+		planKey := GetPlanKey(id)
+		result, err := r.client.client.HGetAll(ctx, planKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retrieve plan %s: %w", id, err)
+		}
+
+		// Skip if plan doesn't exist (could have been deleted)
+		if len(result) == 0 {
+			continue
+		}
+
+		// Parse the plan data
+		plan := &models.Plan{}
+		err = plan.FromMap(result)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse plan data for %s: %w", id, err)
+		}
+
+		plans = append(plans, plan)
+	}
+
+	return plans, nil
+}

--- a/go/internal/storage/valkey_client.go
+++ b/go/internal/storage/valkey_client.go
@@ -46,16 +46,26 @@ func (vc *ValkeyClient) Close() error {
 
 // Keys used for storing data in Valkey
 const (
-	// Project keys
+	// Plan keys (formerly Project)
+	planKeyPrefix = "plan:"
+	plansListKey  = "plans"
+	// Legacy project keys (kept for backward compatibility)
 	projectKeyPrefix = "project:"
 	projectsListKey  = "projects"
 
 	// Task keys
-	taskKeyPrefix      = "task:"
+	taskKeyPrefix   = "task:"
+	planTasksPrefix = "plan_tasks:"
+	// Legacy project tasks keys (kept for backward compatibility)
 	projectTasksPrefix = "project_tasks:"
 )
 
-// GetProjectKey returns the key for a specific project
+// GetPlanKey returns the key for a specific plan
+func GetPlanKey(planID string) string {
+	return planKeyPrefix + planID
+}
+
+// GetProjectKey returns the key for a specific project (legacy)
 func GetProjectKey(projectID string) string {
 	return projectKeyPrefix + projectID
 }
@@ -65,7 +75,12 @@ func GetTaskKey(taskID string) string {
 	return taskKeyPrefix + taskID
 }
 
-// GetProjectTasksKey returns the key for a project's tasks list
+// GetPlanTasksKey returns the key for a plan's tasks list
+func GetPlanTasksKey(planID string) string {
+	return planTasksPrefix + planID
+}
+
+// GetProjectTasksKey returns the key for a project's tasks list (legacy)
 func GetProjectTasksKey(projectID string) string {
 	return projectTasksPrefix + projectID
 }

--- a/go/tests/README.md
+++ b/go/tests/README.md
@@ -1,6 +1,6 @@
 # Testing Directory Structure
 
-This directory contains the testing infrastructure for the valkey-ai-tasks project.
+This directory contains the testing infrastructure for the valkey-ai-tasks application.
 
 ## Directory Structure
 

--- a/go/tests/integration/task_repository_test.go
+++ b/go/tests/integration/task_repository_test.go
@@ -51,12 +51,12 @@ func TestTaskRepositoryCreateBulk(t *testing.T) {
 	defer valkeyClient.Close()
 
 	// Create repositories
-	projectRepo := storage.NewProjectRepository(valkeyClient)
+	planRepo := storage.NewPlanRepository(valkeyClient)
 	taskRepo := storage.NewTaskRepository(valkeyClient)
 
-	// Create a test project
-	project, err := projectRepo.Create(ctx, "test-app", "Test Project", "Test project description")
-	req.NoError(err, "Failed to create test project")
+	// Create a test plan
+	plan, err := planRepo.Create(ctx, "test-app", "Test Plan", "Test plan description")
+	req.NoError(err, "Failed to create test plan")
 
 	// Prepare task inputs for bulk creation
 	taskInputs := []storage.TaskCreateInput{
@@ -76,7 +76,7 @@ func TestTaskRepositoryCreateBulk(t *testing.T) {
 	}
 
 	// Create tasks in bulk
-	createdTasks, err := taskRepo.CreateBulk(ctx, project.ID, taskInputs)
+	createdTasks, err := taskRepo.CreateBulk(ctx, plan.ID, taskInputs)
 	req.NoError(err, "Failed to create tasks in bulk")
 	req.NotNil(createdTasks, "Created tasks should not be nil")
 	req.Equal(3, len(createdTasks), "Should have created 3 tasks")
@@ -106,7 +106,7 @@ func TestTaskRepositoryCreateBulk(t *testing.T) {
 	assert.Equal(2, createdTasks[2].Order)
 
 	// Verify tasks are stored in Valkey
-	tasks, err := taskRepo.ListByProject(ctx, project.ID)
-	req.NoError(err, "Failed to list tasks by project")
-	assert.Equal(3, len(tasks), "Should have 3 tasks in the project")
+	tasks, err := taskRepo.ListByPlan(ctx, plan.ID)
+	req.NoError(err, "Failed to list tasks by plan")
+	assert.Equal(3, len(tasks), "Should have 3 tasks in the plan")
 }

--- a/go/tests/utils/test_data.go
+++ b/go/tests/utils/test_data.go
@@ -50,7 +50,7 @@ func TestTask(projectID string, title string, description string) *models.Task {
 
 	return &models.Task{
 		ID:          uuid.New().String(),
-		ProjectID:   projectID,
+		PlanID:      projectID,
 		Title:       title,
 		Description: description,
 		Status:      models.TaskStatusPending,


### PR DESCRIPTION
## Description
This PR implements the comprehensive renaming of all project-related terminology to plan terminology across the MCP server codebase as outlined in issue #2.

## Changes
- Created new Plan model and PlanRepository
- Updated all references from ProjectID to PlanID in Task model
- Updated repository interfaces to use plan terminology
- Fixed mock repositories to implement the updated interfaces
- Updated MCP server to use plan terminology consistently
- Updated integration tests to use plan terminology
- Updated README files to reflect the terminology change

## Testing
- All unit tests pass
- All integration tests pass
- Build is successful

Closes #2