### PR TITLE
Add Plan Status Feature

### DIFF
--- a/go/internal/models/plan.go
+++ b/go/internal/models/plan.go
@@ -4,14 +4,25 @@ import (
 	"time"
 )
 
+// PlanStatus represents the current status of a plan
+type PlanStatus string
+
+const (
+	PlanStatusNew       PlanStatus = "new"
+	PlanStatusInProgress PlanStatus = "inprogress"
+	PlanStatusCompleted  PlanStatus = "completed"
+	PlanStatusCancelled  PlanStatus = "cancelled"
+)
+
 // Plan represents a collection of related tasks
 type Plan struct {
-	ID            string    `json:"id"`
-	ApplicationID string    `json:"application_id"` // Added field for application association
-	Name          string    `json:"name"`
-	Description   string    `json:"description"`
-	CreatedAt     time.Time `json:"created_at"`
-	UpdatedAt     time.Time `json:"updated_at"`
+	ID            string     `json:"id"`
+	ApplicationID string     `json:"application_id"` // Added field for application association
+	Name          string     `json:"name"`
+	Description   string     `json:"description"`
+	Status        PlanStatus `json:"status"`
+	CreatedAt     time.Time  `json:"created_at"`
+	UpdatedAt     time.Time  `json:"updated_at"`
 }
 
 // NewPlan creates a new plan with the given name and description
@@ -22,6 +33,7 @@ func NewPlan(id, applicationID, name, description string) *Plan {
 		ApplicationID: applicationID,
 		Name:          name,
 		Description:   description,
+		Status:        PlanStatusNew,
 		CreatedAt:     now,
 		UpdatedAt:     now,
 	}
@@ -34,6 +46,7 @@ func (p *Plan) ToMap() map[string]string {
 		"application_id": p.ApplicationID,
 		"name":           p.Name,
 		"description":    p.Description,
+		"status":         string(p.Status),
 		"created_at":     p.CreatedAt.Format(time.RFC3339),
 		"updated_at":     p.UpdatedAt.Format(time.RFC3339),
 	}
@@ -45,6 +58,14 @@ func (p *Plan) FromMap(data map[string]string) error {
 	p.ApplicationID = data["application_id"]
 	p.Name = data["name"]
 	p.Description = data["description"]
+	
+	// Handle status with backward compatibility
+	if status, ok := data["status"]; ok {
+		p.Status = PlanStatus(status)
+	} else {
+		// Default to "new" for plans without status
+		p.Status = PlanStatusNew
+	}
 
 	createdAt, err := time.Parse(time.RFC3339, data["created_at"])
 	if err != nil {


### PR DESCRIPTION
## Description
This PR implements the plan status feature as described in issue #4. It adds a status field to the Plan model with states (new, inprogress, completed, cancelled) and provides both manual and automatic status management.

## Changes
- Added `PlanStatus` type and constants in `models/plan.go`
- Added status field to the `Plan` model with backward compatibility
- Implemented `ListByStatus` method in `PlanRepository` to filter plans by status
- Added `UpdatePlanStatus` method to `TaskRepository` to automatically update plan status based on task statuses
- Added MCP server functions for manual status updates and filtering
- Implemented automatic status updates when tasks are created, updated, or deleted

## Automatic Status Updates
- If all tasks are completed, plan status is set to "completed"
- If any task is in progress, plan status is set to "inprogress"
- If no tasks are in progress but there are pending tasks, plan status is "new"
- If there are no tasks, plan status remains "new"

Closes #4