### PR TITLE
Fix MCP tools for plan status management

### DIFF
--- a/go/internal/mcp/server_mcp.go
+++ b/go/internal/mcp/server_mcp.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/jbrinkman/valkey-ai-tasks/go/internal/models"
 	"github.com/jbrinkman/valkey-ai-tasks/go/internal/storage"
@@ -61,6 +62,8 @@ func (s *MCPGoServer) registerTools() {
 	s.registerListPlansByApplicationTool()
 	s.registerUpdatePlanTool()
 	s.registerDeletePlanTool()
+	s.registerUpdatePlanStatusTool()
+	s.registerListPlansByStatusTool()
 
 	// Task tools
 	s.registerCreateTaskTool()
@@ -194,6 +197,63 @@ func (s *MCPGoServer) registerListPlansByApplicationTool() {
 	})
 }
 
+func (s *MCPGoServer) registerUpdatePlanStatusTool() {
+	tool := mcp.NewTool("update_plan_status",
+		mcp.WithDescription("Update the status of a plan"),
+		mcp.WithString("id",
+			mcp.Required(),
+			mcp.Description("Plan ID"),
+		),
+		mcp.WithString("status",
+			mcp.Required(),
+			mcp.Description("New status value (new, inprogress, completed, cancelled)"),
+		),
+	)
+
+	s.server.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		id, err := request.RequireString("id")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		statusStr, err := request.RequireString("status")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		// Validate status
+		status := models.PlanStatus(statusStr)
+		if status != models.PlanStatusNew &&
+			status != models.PlanStatusInProgress &&
+			status != models.PlanStatusCompleted &&
+			status != models.PlanStatusCancelled {
+			return mcp.NewToolResultError(fmt.Sprintf("Invalid status: %s", statusStr)), nil
+		}
+
+		// Get the existing plan
+		plan, err := s.planRepo.Get(ctx, id)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to get plan: %v", err)), nil
+		}
+
+		// Update status
+		plan.Status = status
+		plan.UpdatedAt = time.Now()
+
+		// Save the updated plan
+		err = s.planRepo.Update(ctx, plan)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to update plan: %v", err)), nil
+		}
+
+		planJson, err := json.Marshal(plan)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal plan: %v", err)), nil
+		}
+		return mcp.NewToolResultText(string(planJson)), nil
+	})
+}
+
 func (s *MCPGoServer) registerUpdatePlanTool() {
 	tool := mcp.NewTool("update_plan",
 		mcp.WithDescription("Update the details or scope of a feature planning plan"),
@@ -266,7 +326,45 @@ func (s *MCPGoServer) registerDeletePlanTool() {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to delete plan: %v", err)), nil
 		}
 
-		return mcp.NewToolResultText("Plan deleted"), nil
+		return mcp.NewToolResultText(`{"result":"Plan deleted"}`), nil
+	})
+}
+
+func (s *MCPGoServer) registerListPlansByStatusTool() {
+	tool := mcp.NewTool("list_plans_by_status",
+		mcp.WithDescription("Find plans by their current status (new, inprogress, completed, cancelled)"),
+		mcp.WithString("status",
+			mcp.Required(),
+			mcp.Description("Plan status to filter by"),
+		),
+	)
+
+	s.server.AddTool(tool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		statusStr, err := request.RequireString("status")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+
+		// Validate status
+		status := models.PlanStatus(statusStr)
+		if status != models.PlanStatusNew &&
+			status != models.PlanStatusInProgress &&
+			status != models.PlanStatusCompleted &&
+			status != models.PlanStatusCancelled {
+			return mcp.NewToolResultError(fmt.Sprintf("Invalid status: %s", statusStr)), nil
+		}
+
+		// Get plans with the specified status
+		plans, err := s.planRepo.ListByStatus(ctx, status)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to list plans by status: %v", err)), nil
+		}
+
+		plansJson, err := json.Marshal(plans)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal plans: %v", err)), nil
+		}
+		return mcp.NewToolResultText(string(plansJson)), nil
 	})
 }
 

--- a/go/internal/mocks/mock_plan_repository.go
+++ b/go/internal/mocks/mock_plan_repository.go
@@ -102,5 +102,24 @@ func (r *MockPlanRepository) ListByApplication(ctx context.Context, applicationI
 	return plans, nil
 }
 
+// ListByStatus returns plans with a specific status from the mock storage
+func (r *MockPlanRepository) ListByStatus(ctx context.Context, status models.PlanStatus) ([]*models.Plan, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	plans := make([]*models.Plan, 0)
+	for _, plan := range r.plans {
+		// For plans without a status field, treat them as "new" for filtering
+		if plan.Status == "" {
+			if status == models.PlanStatusNew {
+				plans = append(plans, plan)
+			}
+		} else if plan.Status == status {
+			plans = append(plans, plan)
+		}
+	}
+	return plans, nil
+}
+
 // Ensure MockPlanRepository implements the PlanRepositoryInterface
 var _ storage.PlanRepositoryInterface = (*MockPlanRepository)(nil)

--- a/go/internal/storage/interfaces.go
+++ b/go/internal/storage/interfaces.go
@@ -14,6 +14,7 @@ type PlanRepositoryInterface interface {
 	Delete(ctx context.Context, id string) error
 	List(ctx context.Context) ([]*models.Plan, error)
 	ListByApplication(ctx context.Context, applicationID string) ([]*models.Plan, error)
+	ListByStatus(ctx context.Context, status models.PlanStatus) ([]*models.Plan, error)
 }
 
 // ProjectRepositoryInterface defines the legacy interface for project storage operations


### PR DESCRIPTION
## Description
This PR adds the missing MCP tools implementation for plan status management. It complements the previous PR #5 that added the plan status feature.

## Changes
- Added `registerUpdatePlanStatusTool` function to register the update_plan_status tool with the MCP server
- Added `registerListPlansByStatusTool` function to register the list_plans_by_status tool with the MCP server
- Updated the `registerTools` method to include both new tools
- Added `ListByStatus` method to the `PlanRepositoryInterface`
- Implemented `ListByStatus` method in the `MockPlanRepository` for testing
- Fixed import for the time package in server_mcp.go

## Related PRs
- Builds on PR #5 which implemented the core plan status feature

This PR ensures that the plan status feature is fully accessible via the MCP API.