### PR TITLE
feat: implement CI/CD workflow for container image builds and releases

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,31 @@
+name: Lint Commit Messages
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: |
+          npm install -g @commitlint/cli @commitlint/config-conventional
+
+      - name: Create commitlint config
+        run: |
+          echo "module.exports = {extends: ['@commitlint/config-conventional']}" > commitlint.config.js
+
+      - name: Validate commit messages
+        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -1,0 +1,105 @@
+name: Build and Publish Container
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/*.md'
+
+jobs:
+  semantic-release:
+    runs-on: ubuntu-latest
+    outputs:
+      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
+      new_release_version: ${{ steps.semantic.outputs.new_release_version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install -g semantic-release @semantic-release/git @semantic-release/changelog @semantic-release/github
+
+      - name: Semantic Release
+        id: semantic
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OUTPUT=$(npx semantic-release --dry-run)
+          if echo "$OUTPUT" | grep -q "The next release version is"; then
+            VERSION=$(echo "$OUTPUT" | grep "The next release version is" | sed 's/.*The next release version is \([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/')
+            echo "new_release_published=true" >> $GITHUB_OUTPUT
+            echo "new_release_version=$VERSION" >> $GITHUB_OUTPUT
+            # Run the actual release
+            npx semantic-release
+          else
+            echo "new_release_published=false" >> $GITHUB_OUTPUT
+            echo "No new version to be released"
+          fi
+        
+  build-and-push:
+    needs: semantic-release
+    if: needs.semantic-release.outputs.new_release_published == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.semantic-release.outputs.new_release_version }}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,64 @@
+{
+    "branches": [
+        "main"
+    ],
+    "plugins": [
+        [
+            "@semantic-release/commit-analyzer",
+            {
+                "preset": "conventionalcommits",
+                "releaseRules": [
+                    {"type": "feat", "release": "minor"},
+                    {"type": "fix", "release": "patch"},
+                    {"type": "docs", "release": "patch"},
+                    {"type": "style", "release": "patch"},
+                    {"type": "refactor", "release": "patch"},
+                    {"type": "perf", "release": "patch"},
+                    {"type": "test", "scope": "*", "release": "patch"},
+                    {"type": "build", "scope": "*", "release": "patch"},
+                    {"type": "ci", "scope": "*", "release": "patch"}
+                ]
+            }
+        ],
+        [
+            "@semantic-release/release-notes-generator",
+            {
+                "preset": "conventionalcommits",
+                "presetConfig": {
+                    "types": [
+                        {"type": "feat", "section": "Features"},
+                        {"type": "fix", "section": "Bug Fixes"},
+                        {"type": "docs", "section": "Documentation"},
+                        {"type": "style", "section": "Styling"},
+                        {"type": "refactor", "section": "Code Refactoring"},
+                        {"type": "perf", "section": "Performance Improvements"},
+                        {"type": "test", "section": "Tests"},
+                        {"type": "build", "section": "Build System"},
+                        {"type": "ci", "section": "Continuous Integration"}
+                    ]
+                }
+            }
+        ],
+        [
+            "@semantic-release/changelog",
+            {
+                "changelogFile": "CHANGELOG.md"
+            }
+        ],
+        [
+            "@semantic-release/github",
+            {
+                "assets": [
+                    {"path": "CHANGELOG.md", "label": "Changelog"}
+                ]
+            }
+        ],
+        [
+            "@semantic-release/git",
+            {
+                "assets": ["CHANGELOG.md", "package.json"],
+                "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+            }
+        ]
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Valkey MCP Task Management Server
 
+[![Build and Publish Container](https://github.com/jbrinkman/valkey-ai-tasks/actions/workflows/container-build.yml/badge.svg)](https://github.com/jbrinkman/valkey-ai-tasks/actions/workflows/container-build.yml)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
+
 A task management system that implements the Model Context Protocol (MCP) for seamless integration with agentic AI tools. This system allows AI agents to create, manage, and track tasks within plans using Valkey as the persistence layer.
 
 ## Features
@@ -185,6 +188,77 @@ The MCP server can be configured using the following environment variables:
 ### HTTP Server Configuration
 - `SERVER_READ_TIMEOUT`: Maximum duration for reading the entire request in seconds (default: 60)
 - `SERVER_WRITE_TIMEOUT`: Maximum duration for writing the response in seconds (default: 60)
+
+## CI/CD Workflow
+
+This project uses GitHub Actions for continuous integration and delivery, automatically building and publishing container images to GitHub Container Registry (ghcr.io).
+
+### Conventional Commits
+
+All commits to this repository must follow the [Conventional Commits](https://www.conventionalcommits.org/) specification. This enables automated versioning, changelog generation, and release management.
+
+The commit message format is:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Where `type` is one of:
+- `feat`: A new feature
+- `fix`: A bug fix
+- `docs`: Documentation changes
+- `style`: Changes that don't affect code meaning (formatting, etc.)
+- `refactor`: Code changes that neither fix bugs nor add features
+- `perf`: Performance improvements
+- `test`: Adding or correcting tests
+- `build`: Changes to build system or dependencies
+- `ci`: Changes to CI configuration
+- `chore`: Other changes that don't modify source or test files
+
+Breaking changes must be indicated by `!` after the type/scope or by including `BREAKING CHANGE:` in the footer.
+
+### Automated Versioning
+
+The project uses [Semantic Release](https://github.com/semantic-release/semantic-release) to automatically determine the next version number based on conventional commits:
+
+- `fix:` commits increment the patch version (1.0.0 → 1.0.1)
+- `feat:` commits increment the minor version (1.0.0 → 1.1.0)
+- Breaking changes increment the major version (1.0.0 → 2.0.0)
+
+### Container Image Workflow
+
+The GitHub Actions workflow automatically:
+
+1. Validates that commits follow the conventional format
+2. Determines the next semantic version based on commit messages
+3. Builds the Docker image using the project's Dockerfile
+4. Tags the image with the semantic version and 'latest' tag
+5. Pushes the image to GitHub Container Registry (ghcr.io)
+6. Creates a Git tag for the version
+7. Generates a changelog
+8. Creates a GitHub Release with release notes
+
+#### Required GitHub Secrets
+
+To enable the CI/CD workflow to function properly, the following GitHub secrets need to be configured in your repository:
+
+- `GITHUB_TOKEN`: This is automatically provided by GitHub Actions and is used for authentication with GitHub Container Registry. Make sure it has the necessary permissions for `packages:read` and `packages:write`.
+
+No additional secrets are required as the workflow uses the built-in `GITHUB_TOKEN` for all authentication needs.
+
+### Using the Container Images
+
+The container images are published to GitHub Container Registry and can be pulled using:
+
+```bash
+docker pull ghcr.io/jbrinkman/valkey-ai-tasks:latest
+# or a specific version
+docker pull ghcr.io/jbrinkman/valkey-ai-tasks:1.2.3
+```
 
 ## MCP API Reference
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,36 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-leading-blank': [1, 'always'],
+    'body-max-line-length': [2, 'always', 100],
+    'footer-leading-blank': [1, 'always'],
+    'footer-max-line-length': [2, 'always', 100],
+    'header-max-length': [2, 'always', 100],
+    'subject-case': [
+      2,
+      'never',
+      ['sentence-case', 'start-case', 'pascal-case', 'upper-case'],
+    ],
+    'subject-empty': [2, 'never'],
+    'subject-full-stop': [2, 'never', '.'],
+    'type-case': [2, 'always', 'lower-case'],
+    'type-empty': [2, 'never'],
+    'type-enum': [
+      2,
+      'always',
+      [
+        'build',
+        'chore',
+        'ci',
+        'docs',
+        'feat',
+        'fix',
+        'perf',
+        'refactor',
+        'revert',
+        'style',
+        'test'
+      ],
+    ],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "valkey-ai-tasks",
+  "version": "0.0.0-development",
+  "private": true,
+  "description": "Task management system that implements the Model Context Protocol (MCP) for seamless integration with agentic AI tools",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jbrinkman/valkey-ai-tasks.git"
+  },
+  "devDependencies": {
+    "@commitlint/cli": "^18.4.3",
+    "@commitlint/config-conventional": "^18.4.3",
+    "@semantic-release/changelog": "^6.0.3",
+    "@semantic-release/git": "^10.0.1",
+    "conventional-changelog-conventionalcommits": "^7.0.2",
+    "semantic-release": "^22.0.12"
+  },
+  "scripts": {
+    "semantic-release": "semantic-release"
+  }
+}


### PR DESCRIPTION
This PR implements a complete CI/CD workflow for automatically building and publishing container images to GitHub Container Registry (ghcr.io) based on semantic versioning.

## Features Added
- GitHub Actions workflow for building and publishing container images
- Semantic Release configuration for automated versioning
- Conventional commit validation workflow
- Docker layer caching for improved build performance
- Comprehensive documentation for the CI/CD process

## Implementation Details
- Added `.github/workflows/container-build.yml` for the main CI/CD pipeline
- Added `.github/workflows/commit-lint.yml` for validating conventional commits
- Created `.releaserc.json` for Semantic Release configuration
- Added `package.json` with necessary dependencies
- Added `commitlint.config.js` for commit message validation
- Updated README with workflow documentation and status badges

Fixes #18