### PR TITLE
feat: add workflow_dispatch support for manual releases

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -10,13 +10,19 @@ on:
       - '**.md'
       - 'docs/**'
       - '.github/*.md'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g. 1.0.0)'
+        required: true
+        type: string
 
 jobs:
   semantic-release:
     runs-on: ubuntu-latest
     outputs:
-      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
-      new_release_version: ${{ steps.semantic.outputs.new_release_version }}
+      new_release_published: ${{ steps.semantic.outputs.new_release_published || steps.manual-version.outputs.new_release_published }}
+      new_release_version: ${{ steps.semantic.outputs.new_release_version || steps.manual-version.outputs.new_release_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,11 +36,27 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      - name: Set manual version
+        id: manual-version
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "new_release_published=true" >> $GITHUB_OUTPUT
+          echo "new_release_version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          # Update package.json version
+          npm version ${{ github.event.inputs.version }} --no-git-tag-version
+          # Create a tag for this version
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git tag -a v${{ github.event.inputs.version }} -m "Release v${{ github.event.inputs.version }}"
+          git push origin v${{ github.event.inputs.version }}
+
       - name: Install dependencies
+        if: github.event_name != 'workflow_dispatch'
         run: npm install -g semantic-release @semantic-release/git @semantic-release/changelog @semantic-release/github
 
       - name: Semantic Release
         id: semantic
+        if: github.event_name != 'workflow_dispatch'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
This PR adds support for manually triggering the container build workflow with a specific version number, allowing for creating releases without waiting for conventional commits.

## Features Added
- Added `workflow_dispatch` event to the container build workflow
- Added a required `version` input parameter for specifying the release version
- Implemented conditional logic to handle manual version input vs. semantic-release
- Added Git tag creation for manual releases
- Updated package.json version for manual releases

## Implementation Details
- Modified `.github/workflows/container-build.yml` to support manual workflow triggers
- Added conditional execution for semantic-release vs. manual version steps
- Ensured Docker image builds correctly with the manually specified version

## Benefits
- Allows creating the initial release without waiting for another PR
- Provides flexibility for creating releases with specific version numbers
- Maintains compatibility with the existing semantic-release automation

## Usage
1. Go to the "Actions" tab in the GitHub repository
2. Select the "Build and Publish Container" workflow
3. Click "Run workflow"
4. Enter the desired version number (e.g., "1.0.0")
5. Run the workflow