### PR TITLE
fix: add missing conventional-changelog-conventionalcommits dependency

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Install dependencies
         if: github.event_name != 'workflow_dispatch'
-        run: npm install -g semantic-release @semantic-release/git @semantic-release/changelog @semantic-release/github
+        run: npm install -g semantic-release @semantic-release/git @semantic-release/changelog @semantic-release/github conventional-changelog-conventionalcommits
 
       - name: Semantic Release
         id: semantic
@@ -109,8 +109,12 @@ jobs:
           {
             "branches": ["main"],
             "plugins": [
-              "@semantic-release/commit-analyzer",
-              "@semantic-release/release-notes-generator"
+              ["@semantic-release/commit-analyzer", {
+                "preset": "conventionalcommits"
+              }],
+              ["@semantic-release/release-notes-generator", {
+                "preset": "conventionalcommits"
+              }]
             ]
           }
           EOL


### PR DESCRIPTION
This PR fixes the semantic-release dependency issue that's causing the workflow to fail.

## Issues Fixed
- Missing dependency `conventional-changelog-conventionalcommits` causing semantic-release to fail
- Incorrect configuration for commit analyzer and release notes generator

## Changes Made
- Added `conventional-changelog-conventionalcommits` to the npm install command
- Updated semantic-release configuration to explicitly use the conventionalcommits preset
- Configured both commit analyzer and release notes generator with the proper preset

## Error Being Fixed
```
Error: Cannot find module 'conventional-changelog-conventionalcommits'
    at importFrom (file:///opt/hostedtoolcache/node/20.19.2/x64/lib/node_modules/semantic-release/node_modules/import-from-esm/index.js:114:17)
```

## Benefits
- Ensures semantic-release can properly analyze conventional commits
- Fixes the build-and-push job skipping issue
- Maintains consistent versioning based on commit messages

This PR complements PR #20, #21, and #22 to ensure the complete release process works correctly.