### PR TITLE
Fix build-and-push job trigger in GitHub workflow

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -164,10 +164,8 @@ jobs:
 
   build-and-push:
     runs-on: ubuntu-latest
-    needs: [manual-release]
-    if: |
-      github.event_name == 'release' || 
-      github.event_name == 'workflow_dispatch'
+    # Only run on release events
+    if: github.event_name == 'release'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
This PR simplifies the workflow by properly leveraging GitHub's event system:

## Changes
- Simplified the build-and-push job to only run on release events
- Removed complex job dependencies and conditions
- Restored necessary permissions for the build-and-push job

This approach is more maintainable because:
1. It uses GitHub's release event as the trigger between release creation and Docker builds
2. Both semantic-release and manual releases create GitHub Release events
3. The build-and-push job now has a simple condition: `if: github.event_name == 'release'`

This should fix the issue where the build-and-push job wasn't being triggered after a release was created.