### PR TITLE
Fix permissions for GitHub release workflow triggers

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -84,6 +84,9 @@ jobs:
   semantic-release:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      actions: write
     
     steps:
       - name: Checkout
@@ -109,6 +112,9 @@ jobs:
   manual-release:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: write
+      actions: write
     
     steps:
       - name: Checkout
@@ -159,7 +165,10 @@ jobs:
           tag_name: v${{ github.event.inputs.version }}
           generate_release_notes: true
           body_path: CHANGELOG.md
+          draft: false
+          prerelease: false
         env:
+          # Use a token with workflow permissions
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-and-push:


### PR DESCRIPTION
This PR fixes the issue where the build-and-push job wasn't being triggered after a manual release.

## Changes
- Added explicit permissions to both release jobs:
  ```yaml
  permissions:
    contents: write
    actions: write
  ```
  This ensures that both the semantic-release and manual-release jobs have the necessary permissions to create GitHub releases that can trigger subsequent workflows.

- Made the GitHub release creation more explicit:
  ```yaml
  - name: Create GitHub Release
    uses: softprops/action-gh-release@v1
    with:
      # ...
      draft: false
      prerelease: false
  ```
  By explicitly setting `draft: false` and `prerelease: false`, we ensure the release is published immediately and can trigger the workflow.

The issue was related to permissions. By default, the `GITHUB_TOKEN` used in GitHub Actions has limited permissions and doesn't trigger subsequent workflow runs (to prevent accidental workflow loops). By explicitly granting the `actions: write` permission, we allow the token to trigger other workflows when creating a release.