### PR TITLE
ci: Add manual trigger to container publish workflow

### DIFF
--- a/.github/workflows/publish-container-image.yml
+++ b/.github/workflows/publish-container-image.yml
@@ -3,6 +3,12 @@ name: Build and Publish Container
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to use for container tagging'
+        required: true
+        type: string
 
 jobs:
   build-and-push-container:


### PR DESCRIPTION
This PR adds a manual trigger (`workflow_dispatch`) to the container publish workflow, allowing it to be run manually in addition to the existing release trigger.

### Changes:
- Added `workflow_dispatch` event trigger to the publish-container-image.yml workflow
- Added input parameter for version when manually triggering the workflow

### Benefits:
- Provides a way to manually trigger container builds when needed
- Helps with troubleshooting by allowing manual execution of the workflow
- Maintains the existing automatic trigger on release publish events

This change will help us test if the workflow itself is functional and isolate whether the issue is with the release event trigger specifically.