### PR TITLE
ci: Enhance container workflow triggers

### DIFF
--- a/.github/workflows/publish-container-image.yml
+++ b/.github/workflows/publish-container-image.yml
@@ -2,7 +2,10 @@ name: Build and Publish Container
 
 on:
   release:
-    types: [published]
+    types: [published, created, released]
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
This PR enhances the container workflow triggers to ensure it runs reliably when releases are created.

### Changes:
- Expanded release event types to include `published`, `created`, and `released`
- Added a tag-based trigger that activates on any tag push matching the pattern `v*`
- Maintains the manual workflow_dispatch trigger for direct execution

### Benefits:
- Multiple redundant trigger mechanisms ensure the workflow runs when expected
- Tag-based trigger provides a reliable alternative if release events aren't firing
- More comprehensive coverage of release-related events

This approach addresses the issue where the workflow wasn't being triggered automatically on releases by providing multiple paths for activation.