### PR TITLE
Fix MCP resource discovery for WindSurf and GitHub Copilot clients

### DIFF
--- a/internal/mcp/server_mcp.go
+++ b/internal/mcp/server_mcp.go
@@ -61,6 +61,7 @@ func NewMCPGoServer(planRepo storage.PlanRepositoryInterface, taskRepo storage.T
 		"Valkey Feature Planning & Task Management",
 		"1.0.0",
 		server.WithToolCapabilities(true),
+		server.WithResourceCapabilities(true, true),
 		server.WithRecovery(),
 	)
 


### PR DESCRIPTION
## Description

Fixes #47 

This PR enables MCP resource discovery for clients like WindSurf and GitHub Copilot by adding resource capabilities to the MCP server initialization.

## Problem

MCP resources were properly defined and registered but not discoverable by clients because the server was missing resource capabilities configuration.

## Changes

- **`internal/mcp/server_mcp.go`**: Added `server.WithResourceCapabilities(true, true)` to the MCP server initialization

## Before
```go
s := server.NewMCPServer(
    "Valkey Feature Planning & Task Management",
    "1.0.0",
    server.WithToolCapabilities(true),
    server.WithRecovery(),
)
```

## After
```go
s := server.NewMCPServer(
    "Valkey Feature Planning & Task Management",
    "1.0.0",
    server.WithToolCapabilities(true),
    server.WithResourceCapabilities(true, true),
    server.WithRecovery(),
)
```

## Impact

This change enables MCP clients to:
1. ✅ Discover that the server supports resources
2. ✅ List available resource templates
3. ✅ Access plan resources via the defined URIs:
   - `ai-tasks://plans/{id}/full` - Single plan with tasks
   - `ai-tasks://plans/full` - All plans with tasks
   - `ai-tasks://applications/{app_id}/plans/full` - Plans for specific application

## Testing

- [x] Resources work correctly with Postman (STDIO and Streamable HTTP)
- [x] Server compiles without errors
- [ ] Resources are discoverable in WindSurf/GitHub Copilot (to be verified after merge)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update